### PR TITLE
Found errors with OpenERP Integration

### DIFF
--- a/lib/open_erp/customer_manager.rb
+++ b/lib/open_erp/customer_manager.rb
@@ -8,6 +8,7 @@ module OpenErp
     end
 
     def update!
+      update_category
       update_addresses
 
       customer.save
@@ -15,6 +16,10 @@ module OpenErp
     end
 
     private
+
+    def update_category
+      customer.category_id       = []
+    end
 
     def update_addresses
       if payload['order']['shipping_address'] == payload['order']['billing_address']
@@ -58,6 +63,8 @@ module OpenErp
       if address['state'].present?
         ship_customer.state_id = ResCountryState.find(name: address['state']).first.id
       end
+
+      ship_customer.category_id       = []
 
       ship_customer.save
     end

--- a/lib/open_erp/order_builder.rb
+++ b/lib/open_erp/order_builder.rb
@@ -31,7 +31,7 @@ module OpenErp
       order.partner_invoice_id = order.partner_id
       order.partner_shipping_id = set_partner_shipping_id(payload['order']['email'], order)
 
-      order.shop_id = config[:openerp_shop]
+      # order.shop_id = config['openerp_shop'] # is this needed? shop_id doesnt seem to exist anymore
 
       order.pricelist_id = set_pricelist(config['openerp_pricelist'])
       order.incoterm = StockIncoterms.find(:all, :domain => ['name', '=', config['openerp_shipping_name']]).first.try(:id)
@@ -207,7 +207,7 @@ module OpenErp
                      OpenErp::CustomerManager.new(result.first, payload)
                    end
 
-        order.partner_id = customer.update!.id
+        order.partner_id = customer.update!
       end
 
       def set_partner_shipping_id(email, order)


### PR DESCRIPTION
Found a couple errors when trying to integrate:

1. There seems to be an error with the 'ooor' gem that is sending an empty object vs an empty array when setting the category_id on a customer, which is throwing an error. Solution was to set and pass the appropriate default empty array. (in customer_manager.rb)
2. The shop_id does not seem to exist on an order object anymore, so an undefined method error was being thrown. I commented out this line for now, may be worth checking in with the openerp api guys to see if this is the case. (in order_builder.rb)
3. The partner_id on the order object is expecting the full partner/customer object and not just the id so this was throwing an error on the db call.

Orders are now being sent successfully with these changes.
